### PR TITLE
fix(jQueryShim): cachebuster separator

### DIFF
--- a/src/jQueryShim.js
+++ b/src/jQueryShim.js
@@ -81,12 +81,12 @@ const ajax = function(options) {
   };
 
   request.withCredentials = options.xhrFields.withCredentials;
-  var cacheBuster = "&_=" + new Date().getTime();
-  if (options.url.indexOf("&_=") === -1) {
+  var cacheBuster = `${options.url.indexOf("?") === -1 ? "?" : "&"}_=` + new Date().getTime();
+  if (options.url.indexOf("&_=") === -1 && options.url.indexOf("?_=") === -1) {
     options.url += cacheBuster;
   }
   else {
-    options.url.replace(/&_=\d+/, cacheBuster);
+    options.url.replace(/&_=\d+/, cacheBuster).replace(/\?_=\d+/, cacheBuster);
   }
   request.open(options.type, options.url);
   request.setRequestHeader('content-type', options.contentType);


### PR DESCRIPTION
The separator of the cache buster always used `&`. But if no query params exist on the url, there will be no initial query param declaration with `?`  
